### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3-pre
+
+- `IMPROVED`: The README for even better legibility.
+- `IMPROVED`: Using asset image from github.
+
 ## 1.0.2
 
 - `ADDED`: An XContainers preview image for the README.
@@ -63,7 +68,6 @@
 - `ADDED`: XCard.
 - `ADDED`: XTheme to manage the shared properties.
 
----
 
 ## How to use
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- `CHANGED`: Fixed library name (from `x_container` to `x_containers`).
+
 ## 1.1.0
 
 - `ADDED`: a makefile containing a few utility commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.2.0
+
+- `ADDED`: [XListTile] as a way to have a box-less reusable tile layout.
+- `ADDED`: A preset [TextTheme] to [xTheme.getTheme] that can be fully or partially overridden.
+- `CHANGED`: [XCard] and [XSnackbar] use [XListTile].
+- `CHANGED`: The documentation which is now handled in part by macros.
+- `CHANGED`: The example to showcase changing the text theme through [xTheme].
+
+- `BREAKING`: [XSnackbar] doesn't use the [titleStyle] and [contentStyle] properties which are handled by the text theme.
+
 ## 1.1.1
 
 - `CHANGED`: Fixed library name (from `x_container` to `x_containers`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 1.0.3-pre
+## 1.1.0
+
+- `ADDED`: a makefile containing a few utility commands.
+- `IMPROVED`: The documentation comments on the class constructors.
+- `IMPROVED`: The [XDialog] buttons turn invisible if their label is set to [null].
+
+- `BREAKING`: In [XSnackbar], the field [message] is renamed to [content] to match the naming of other classes.
+- `BREAKING`: In [XCard], the field [subtitle] is renamed to [content] to match the naming of other classes.
+
+- `CHANGED`: The example to match the breaking changes.
+
+## 1.0.3-dev.1
 
 - `IMPROVED`: The README for even better legibility.
 - `IMPROVED`: Using asset image from github.
@@ -82,6 +93,7 @@ Keywords:
 - `CHANGED`: When you switch some code for different code (for instance, if we decided to radically change the way the movies are displayed).
 - `DELETED`: When you remove some feature or code.
 - `REFACTORED`: When you change file names or a linting rule.
+- `BREAKING`: Any breaking change.
 
 ## WARNING
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Flutter package offering more adaptive and easy-to-use container widgets.
 I initially created the `XContainer` (formerly `ShadowContainer`) as a way to have a customizable container with a shadow.
 Then I implemented the other XContainers to easily match and uniformize the style of the containers in my projects without repeating style code everywhere.
 
-![Here is a preview of what you can do with XContainers.](assets/preview.png)
+![Here is a preview of what you can do with XContainers.](https://raw.githubusercontent.com/XLhinares/x_containers/main/assets/preview.png)
 
 ## **Features**
 
@@ -30,24 +30,23 @@ import 'package:x_containers/x_containers.dart';
 
 ## **Usage**
 
-This package gives you access to the following XContainers:
+This package gives you access to the following XContainers, as well as a `xTheme` singleton and a `XLayout` class.  
+All these are explained below.
 
 | Name | Description |
 | :- | :- |
+||
+|| **XContainers**
 | `XContainer` | A container-type widget with a shadow and some more customization than a regular container.
 | `XInkContainer` | A container-type widget with a shadow embedding a tappable InkWell for splash animations.
 | `XCard` | A card-type widget meant to replace ListTiles inside Cards, it also fixes the issue of ListTile's leading and trailing properties not being leveled.
 | `XDialog` | A custom dialog object that can be displayed with its `show` method.
 | `XSnackbar` | A custom dialog object that can be displayed with its `show` method.
+||
+|| **xTheme & XLayout**
+| `xTheme` | It allows you to customize the default properties shared by all the XContainers, and create app themes.
+| `XLayout` | It is a collection of constants used to uniformize the look of your app (for instance, it contains preset padding values or preset SizedBox).
 
-You will also find a `xTheme` singleton and a `XLayout` class.
-
-| Name | Description |
-| :- | :- |
-| `xTheme` | it allows you to customize the default properties shared by all the XContainers, and create app themes.
-| `XLayout` | is a collection of constants used to uniformize the look of your app (for instance, it contains preset padding values or preset `SizedBox`).
-
-All these are explained below.
 
 ### **XContainers**
 

--- a/example/lib/globals.dart
+++ b/example/lib/globals.dart
@@ -3,7 +3,7 @@ import "package:get/get.dart";
 import "package:x_containers/x_containers.dart";
 
 /// A preset theme for light mode.
-ThemeData lightMode = xTheme.getTheme(
+ThemeData lightTheme = xTheme.getTheme(
   mode: ThemeMode.light,
   primary: const Color(0xFFB4B8AB),
   secondary: const Color(0xFF284B63),
@@ -11,6 +11,11 @@ ThemeData lightMode = xTheme.getTheme(
   backgroundAlt: const Color(0xFFEEF0EB),
   cardColor: const Color(0xFFB4B8AB),
   containerColor: const Color(0xFFB4B8AB),
+  textTheme: TextTheme(
+    titleMedium: const TextStyle().copyWith(
+        fontWeight: FontWeight.w700, fontStyle: FontStyle.italic, fontSize: 16),
+    bodyMedium: const TextStyle().copyWith(fontSize: 14),
+  ),
 );
 
 /// A preset theme for dark mode.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,7 @@ class ExampleApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       home: const Home(),
+      theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: ThemeMode.dark,
     );

--- a/example/lib/widgets/x_card.dart
+++ b/example/lib/widgets/x_card.dart
@@ -16,7 +16,7 @@ class ExampleXCard extends StatelessWidget {
         size: XLayout.paddingL,
       ),
       title: const Text("This is an [XCard]."),
-      subtitle:
+      content:
           const Text("It works similarly to a [ListTile] within a [Card]."),
     );
   }

--- a/example/lib/widgets/x_dialog.dart
+++ b/example/lib/widgets/x_dialog.dart
@@ -11,7 +11,7 @@ class ExampleXDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextButton(
-      style: ButtonStyle(
+      style: const ButtonStyle().copyWith(
         backgroundColor:
             MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
       ),
@@ -21,9 +21,8 @@ class ExampleXDialog extends StatelessWidget {
         cancelText: "No",
         onValidate: () => toggleTheme(),
       ).show(context),
-      child: Text(
+      child: const Text(
         "Tap to display an [XDialog].",
-        style: Theme.of(context).textTheme.bodyMedium,
       ),
     );
   }

--- a/example/lib/widgets/x_snackbar.dart
+++ b/example/lib/widgets/x_snackbar.dart
@@ -15,6 +15,7 @@ class ExampleXSnackbar extends StatelessWidget {
       ),
       onPressed: () => XSnackbar.text(
         title: "Here it is :)",
+        content: "You can add some more text if you'd like.",
       ).show(context),
       child: Text(
         "Tap to display an [XSnackbar].",

--- a/lib/src/dialogs/x_dialog.dart
+++ b/lib/src/dialogs/x_dialog.dart
@@ -4,7 +4,11 @@ import "package:flutter/material.dart";
 
 import "../../x_containers.dart";
 
-/// A custom [AlertDialog]
+/// A custom [AlertDialog] matching the style of XContainers.
+///
+/// It features a title and a content widget and two callback buttons.
+/// The buttons are traditionally used for "yes" and "no" behaviors
+/// but can be renamed and will not be displayed if their name is set to [null].
 class XDialog {
   // VARIABLES =================================================================
 
@@ -44,6 +48,12 @@ class XDialog {
   // CONSTRUCTOR ===============================================================
 
   /// Returns an instance of [XDialog] matching the given parameters.
+  ///
+  /// - [title] and [content] are widgets.
+  /// - [cancelText] and [validateText] are the Strings displayed on the buttons.
+  /// - [onCancel] and [onValidate] are the callbacks run when the buttons are pressed.
+  /// - [color] is the background color of the dialog.
+  /// - [backgroundBlur] is the intensity of the gaussian blur applied to stuff that is "behind" the dialog.
   const XDialog({
     required this.title,
     this.content,
@@ -56,6 +66,12 @@ class XDialog {
   });
 
   /// Returns an XDialog displaying only text messages.
+  ///
+  /// - [title] and [content] are Strings.
+  /// - [cancelText] and [validateText] are the Strings displayed on the buttons.
+  /// - [onCancel] and [onValidate] are the callbacks run when the buttons are pressed.
+  /// - [color] is the background color of the dialog.
+  /// - [backgroundBlur] is the intensity of the gaussian blur applied to stuff that is "behind" the dialog.
   factory XDialog.text({
     required String title,
     String? content,
@@ -63,6 +79,7 @@ class XDialog {
     String? validateText = "Okay",
     void Function()? onCancel,
     void Function()? onValidate,
+    Color? color,
     double backgroundBlur = 1,
   }) =>
       XDialog(
@@ -72,6 +89,7 @@ class XDialog {
         validateText: validateText,
         onCancel: onCancel,
         onValidate: onValidate,
+        color: color,
         backgroundBlur: backgroundBlur,
       );
 
@@ -87,6 +105,7 @@ class XDialog {
           sigmaY: backgroundBlur,
         ),
         child: AlertDialog(
+          contentPadding: xTheme.padding,
           backgroundColor: color ?? Theme.of(context).cardColor,
           shape:
               RoundedRectangleBorder(borderRadius: xTheme.dialogBorderRadius),
@@ -99,19 +118,25 @@ class XDialog {
                   Theme.of(context).textTheme.bodyMedium ?? const TextStyle(),
               child: content ?? const SizedBox()),
           actions: <Widget>[
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-                onCancel?.call();
-              },
-              child: Text(cancelText ?? "Cancel"),
+            Visibility(
+              visible: cancelText != null,
+              child: TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  onCancel?.call();
+                },
+                child: Text(cancelText ?? "Cancel"),
+              ),
             ),
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-                onValidate?.call();
-              },
-              child: Text(validateText ?? "Okay"),
+            Visibility(
+              visible: validateText != null,
+              child: TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  onValidate?.call();
+                },
+                child: Text(validateText ?? "Okay"),
+              ),
             ),
           ],
         ),

--- a/lib/src/dialogs/x_dialog.dart
+++ b/lib/src/dialogs/x_dialog.dart
@@ -12,10 +12,10 @@ import "../../x_containers.dart";
 class XDialog {
   // VARIABLES =================================================================
 
-  /// The text to display at the top of the dialog.
+  /// {@macro x_containers.docs.title}
   final Widget title;
 
-  /// The description of the effect of the dialog.
+  /// {@macro x_containers.docs.content}
   final Widget? content;
 
   /// The text displayed on the cancel button.
@@ -28,7 +28,7 @@ class XDialog {
   /// If it is [null] then the button isn't displayed.
   final String? validateText;
 
-  /// The color of the background of the box.
+  /// {@macro x_containers.docs.color}
   final Color? color;
 
   /// The behavior to execute when the "cancel" button is pressed.
@@ -110,13 +110,15 @@ class XDialog {
           shape:
               RoundedRectangleBorder(borderRadius: xTheme.dialogBorderRadius),
           title: DefaultTextStyle(
-              style:
-                  Theme.of(context).textTheme.titleSmall ?? const TextStyle(),
-              child: title),
+            style: const TextStyle()
+                .merge(Theme.of(context).textTheme.titleMedium),
+            child: title,
+          ),
           content: DefaultTextStyle(
-              style:
-                  Theme.of(context).textTheme.bodyMedium ?? const TextStyle(),
-              child: content ?? const SizedBox()),
+            style:
+                const TextStyle().merge(Theme.of(context).textTheme.bodyMedium),
+            child: content ?? const SizedBox(),
+          ),
           actions: <Widget>[
             Visibility(
               visible: cancelText != null,

--- a/lib/src/dialogs/x_snack_bar.dart
+++ b/lib/src/dialogs/x_snack_bar.dart
@@ -8,28 +8,16 @@ class XSnackbar {
 
   // CONTENTS ------------------------------------------------------------------
 
-  /// The title of the snackbar.
-  ///
-  /// It should summarize the contents.
+  /// {@macro x_containers.docs.title}
   final Widget title;
 
-  /// A more extensive description of the snackbar.
+  /// {@macro x_containers.docs.content}
   final Widget? content;
 
-  /// An optional [TextStyle] to customize the title.
-  ///
-  /// It is applied to all [Text] children as default style.
-  final TextStyle? titleStyle;
-
-  /// An optional [TextStyle] to customize the contents.
-  ///
-  /// It is applied to all [Text] children as default style.
-  final TextStyle? contentStyle;
-
-  /// An optional widget to display to the right of the snackbar.
+  /// {@macro x_containers.docs.trailing}
   final Widget? trailing;
 
-  /// An optional [Widget] to display at the left of the snackbar.
+  /// {@macro x_containers.docs.leading}
   final Widget? leading;
 
   // PROPERTIES ---------------------------------------------------------------
@@ -39,7 +27,7 @@ class XSnackbar {
   /// Usually used when the screen is too wide.
   final double? maxWidth;
 
-  /// The background color of the Snackbar.
+  /// {@macro x_containers.docs.color}
   final Color? color;
 
   // BEHAVIOR ------------------------------------------------------------------
@@ -53,7 +41,6 @@ class XSnackbar {
   ///
   /// PARAMETERS:
   /// > - [title], [content], [leading] and [trailing] are widgets.
-  /// > - [titleStyle] and [contentStyle] are the default text style for [Text] widgets inside [title] and [content].
   /// > - [color] is the background color of the snackbar.
   /// > - [maxWidth] is the maximum allowed width of the Snackbar;
   /// > if null, the Snackbar takes the whole screen minus a small padding.
@@ -61,8 +48,6 @@ class XSnackbar {
   const XSnackbar({
     required this.title,
     this.content,
-    this.titleStyle,
-    this.contentStyle,
     this.leading,
     this.trailing,
     this.color,
@@ -86,8 +71,6 @@ class XSnackbar {
   factory XSnackbar.withUndo({
     required Widget title,
     Widget? content,
-    TextStyle? titleStyle,
-    TextStyle? contentStyle,
     Widget? leading,
     Color? color,
     Duration duration = const Duration(seconds: 4),
@@ -98,8 +81,6 @@ class XSnackbar {
       XSnackbar(
         title: title,
         content: content,
-        titleStyle: titleStyle,
-        contentStyle: contentStyle,
         leading: leading,
         trailing: TextButton(
           onPressed: onUndo,
@@ -132,10 +113,16 @@ class XSnackbar {
     double? maxWidth,
   }) =>
       XSnackbar(
-        title: Text(title),
-        content: content == null ? null : Text(content),
-        titleStyle: titleStyle,
-        contentStyle: contentStyle,
+        title: Text(
+          title,
+          style: titleStyle,
+        ),
+        content: content == null
+            ? null
+            : Text(
+                content,
+                style: contentStyle,
+              ),
         leading: leading,
         trailing: trailing,
         color: color,
@@ -170,10 +157,16 @@ class XSnackbar {
     void Function()? onUndo,
   }) =>
       XSnackbar(
-        title: Text(title),
-        content: content == null ? null : Text(content),
-        titleStyle: titleStyle,
-        contentStyle: contentStyle,
+        title: Text(
+          title,
+          style: titleStyle,
+        ),
+        content: content == null
+            ? null
+            : Text(
+                content,
+                style: contentStyle,
+              ),
         leading: leading,
         trailing: TextButton(
           onPressed: onUndo,
@@ -189,17 +182,15 @@ class XSnackbar {
   /// Displays the snackbar on the screen.
   void show(BuildContext context) => ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: ListTile(
+          content: XListTile(
             title: DefaultTextStyle(
-              style: titleStyle ??
-                  Theme.of(context).textTheme.titleMedium ??
-                  const TextStyle(),
+              style: const TextStyle()
+                  .merge(Theme.of(context).textTheme.titleMedium),
               child: title,
             ),
-            subtitle: DefaultTextStyle(
-              style: contentStyle ??
-                  Theme.of(context).textTheme.bodyMedium ??
-                  const TextStyle(),
+            content: DefaultTextStyle(
+              style: const TextStyle()
+                  .merge(Theme.of(context).textTheme.bodyMedium),
               child: content ?? const SizedBox(),
             ),
             leading: leading == null

--- a/lib/src/dialogs/x_snack_bar.dart
+++ b/lib/src/dialogs/x_snack_bar.dart
@@ -1,29 +1,30 @@
-import "dart:math";
-
 import "package:flutter/material.dart";
 
 import "../../x_containers.dart";
 
-/// A custom snackbar matching the theme of the app.
-///
-/// It can be shown anywhere without passing the context thanks to the [Get]
-/// package.
+/// A custom snackbar matching the style of XContainers.
 class XSnackbar {
   // VARIABLES =================================================================
 
   // CONTENTS ------------------------------------------------------------------
 
-  /// The title of the snackbar: sums up the message.
+  /// The title of the snackbar.
+  ///
+  /// It should summarize the contents.
   final Widget title;
 
   /// A more extensive description of the snackbar.
-  final Widget? message;
+  final Widget? content;
 
   /// An optional [TextStyle] to customize the title.
+  ///
+  /// It is applied to all [Text] children as default style.
   final TextStyle? titleStyle;
 
-  /// An optional [TextStyle] to customize the message.
-  final TextStyle? messageStyle;
+  /// An optional [TextStyle] to customize the contents.
+  ///
+  /// It is applied to all [Text] children as default style.
+  final TextStyle? contentStyle;
 
   /// An optional widget to display to the right of the snackbar.
   final Widget? trailing;
@@ -44,46 +45,65 @@ class XSnackbar {
   // BEHAVIOR ------------------------------------------------------------------
 
   /// The duration for which the widget is displayed.
-  final Duration? duration;
+  final Duration duration;
 
   // CONSTRUCTOR ===============================================================
 
   /// Returns a [XSnackbar] instance which can be displayed via the [show] method.
+  ///
+  /// PARAMETERS:
+  /// > - [title], [content], [leading] and [trailing] are widgets.
+  /// > - [titleStyle] and [contentStyle] are the default text style for [Text] widgets inside [title] and [content].
+  /// > - [color] is the background color of the snackbar.
+  /// > - [maxWidth] is the maximum allowed width of the Snackbar;
+  /// > if null, the Snackbar takes the whole screen minus a small padding.
+  /// > - [duration] is the time during which the snackbar is displayed.
   const XSnackbar({
     required this.title,
-    this.message,
+    this.content,
     this.titleStyle,
-    this.messageStyle,
+    this.contentStyle,
     this.leading,
     this.trailing,
     this.color,
     this.maxWidth,
-    this.duration,
+    this.duration = const Duration(seconds: 4),
   });
 
   /// Returns an instance of [XSnackbar] with an undo button.
   ///
   /// The undo button replaces the trailing widget so none can be set.
+  ///
+  /// PARAMETERS:
+  /// > - [title], [content] and [leading] are widgets.
+  /// > - [titleStyle] and [contentStyle] are the default text style for [Text] widgets inside [title] and [content].
+  /// > - [color] is the background color of the snackbar.
+  /// > - [maxWidth] is the maximum allowed width of the Snackbar;
+  /// > if null, the Snackbar takes the whole screen minus a small padding.
+  /// > - [duration] is the time during which the snackbar is displayed.
+  /// > - [undoLabel] is the string displayed on the "undo" button.
+  /// > - [onUndo] is a callback called when the "undo" button is pressed.
   factory XSnackbar.withUndo({
     required Widget title,
-    Widget? message,
+    Widget? content,
     TextStyle? titleStyle,
-    TextStyle? messageStyle,
+    TextStyle? contentStyle,
     Widget? leading,
     Color? color,
-    Duration? duration,
+    Duration duration = const Duration(seconds: 4),
     double? maxWidth,
+    String undoLabel = "Undo",
     void Function()? onUndo,
   }) =>
       XSnackbar(
         title: title,
-        message: message,
+        content: content,
         titleStyle: titleStyle,
-        messageStyle: messageStyle,
+        contentStyle: contentStyle,
         leading: leading,
         trailing: TextButton(
           onPressed: onUndo,
-          child: const Text("Undo"),
+          child: Text(undoLabel),
         ),
         color: color,
         duration: duration,
@@ -91,22 +111,31 @@ class XSnackbar {
       );
 
   /// Returns an instance of [XSnackbar] made for displaying mainly text.
+  ///
+  /// PARAMETERS:
+  /// > - [title] and [content] are strings.
+  /// > - [titleStyle] and [contentStyle] are the text styles used for [title] and [content].
+  /// > - [leading] and [trailing] are widgets.
+  /// > - [color] is the background color of the snackbar.
+  /// > - [maxWidth] is the maximum allowed width of the Snackbar;
+  /// > if null, the Snackbar takes the whole screen minus a small padding.
+  /// > - [duration] is the time during which the snackbar is displayed.
   factory XSnackbar.text({
     required String title,
-    String? message,
+    String? content,
     TextStyle? titleStyle,
-    TextStyle? messageStyle,
+    TextStyle? contentStyle,
     Widget? leading,
     Widget? trailing,
     Color? color,
-    Duration? duration,
+    Duration duration = const Duration(seconds: 4),
     double? maxWidth,
   }) =>
       XSnackbar(
         title: Text(title),
-        message: message == null ? null : Text(message),
+        content: content == null ? null : Text(content),
         titleStyle: titleStyle,
-        messageStyle: messageStyle,
+        contentStyle: contentStyle,
         leading: leading,
         trailing: trailing,
         color: color,
@@ -117,26 +146,38 @@ class XSnackbar {
   /// Returns an instance of [XSnackbar] made for displaying mainly text with an undo button.
   ///
   /// The undo button replaces the trailing widget so none can be set.
+  ///
+  /// PARAMETERS:
+  /// > - [title] and [content] are strings.
+  /// > - [titleStyle] and [contentStyle] are the text styles used for [title] and [content].
+  /// > - [leading] is a widget.
+  /// > - [color] is the background color of the snackbar.
+  /// > - [maxWidth] is the maximum allowed width of the Snackbar;
+  /// > if null, the Snackbar takes the whole screen minus a small padding.
+  /// > - [duration] is the time during which the snackbar is displayed.
+  /// > - [undoLabel] is the string displayed on the "undo" button.
+  /// > - [onUndo] is a callback called when the "undo" button is pressed.
   factory XSnackbar.textWithUndo({
     required String title,
-    String? message,
+    String? content,
     TextStyle? titleStyle,
-    TextStyle? messageStyle,
+    TextStyle? contentStyle,
     Widget? leading,
     Color? color,
-    Duration? duration,
+    Duration duration = const Duration(seconds: 4),
     double? maxWidth,
+    String undoLabel = "Undo",
     void Function()? onUndo,
   }) =>
       XSnackbar(
         title: Text(title),
-        message: message == null ? null : Text(message),
+        content: content == null ? null : Text(content),
         titleStyle: titleStyle,
-        messageStyle: messageStyle,
+        contentStyle: contentStyle,
         leading: leading,
         trailing: TextButton(
           onPressed: onUndo,
-          child: const Text("Undo"),
+          child: Text(undoLabel),
         ),
         duration: duration,
         color: color,
@@ -156,10 +197,10 @@ class XSnackbar {
               child: title,
             ),
             subtitle: DefaultTextStyle(
-              style: messageStyle ??
+              style: contentStyle ??
                   Theme.of(context).textTheme.bodyMedium ??
                   const TextStyle(),
-              child: message ?? const SizedBox(),
+              child: content ?? const SizedBox(),
             ),
             leading: leading == null
                 ? null
@@ -172,7 +213,7 @@ class XSnackbar {
             trailing: trailing,
           ),
           behavior: SnackBarBehavior.floating,
-          duration: duration ?? const Duration(seconds: 3),
+          duration: duration,
           padding: EdgeInsets.symmetric(
             vertical: XLayout.paddingS,
             horizontal: XLayout.paddingM,
@@ -181,8 +222,8 @@ class XSnackbar {
             borderRadius: xTheme.borderRadius,
           ),
           backgroundColor: color ?? Theme.of(context).cardColor,
-          width: min(MediaQuery.of(context).size.width - 2 * XLayout.paddingS,
-              maxWidth ?? double.infinity),
+          width: maxWidth ??
+              MediaQuery.of(context).size.width - 2 * XLayout.paddingS,
         ),
       );
 }

--- a/lib/src/docs.dart
+++ b/lib/src/docs.dart
@@ -1,0 +1,192 @@
+import "package:flutter/material.dart";
+
+/// An un-instantiable class containing the common documentation for the package.
+class Documentation {
+  // CHILDREN ==================================================================
+
+  // CHILD
+  /// {@template x_containers.docs.child}
+  /// The widget below this in the widget tree.
+  /// {@endtemplate}
+  final Widget child;
+
+  // TITLE
+  /// {@template x_containers.docs.title}
+  /// The title of the tile.
+  ///
+  /// It should summarize the contents of the tile.
+  /// {@endtemplate}
+  final Widget title;
+
+  // CONTENT
+  /// {@template x_containers.docs.content}
+  /// The contents of the tile.
+  ///
+  /// It is optional but if you leave it empty, you might want to consider
+  /// trading this widget for an [XContainer] or an [XInkContainer].
+  /// {@endtemplate}
+  final Widget content;
+
+  // LEADING
+  /// {@template x_containers.docs.leading}
+  /// An widget to be displayed on the left of the tile.
+  ///
+  /// It is optional and won't take space if set to [null].
+  ///
+  /// It is usually used to place icons or elements identifying the type of
+  /// content at a glance.
+  /// {@endtemplate}
+  final Widget leading;
+
+  // TRAILING
+  /// {@template x_containers.docs.trailing}
+  /// An widget to be displayed on the right of the tile.
+  ///
+  /// It is optional and won't take space if set to [null].
+  /// {@endtemplate}
+  final Widget trailing;
+
+  // COLORS =====================================================================
+
+  // COLOR
+  /// {@template x_containers.docs.color}
+  /// The main color of the box.
+  /// {@endtemplate}
+  final Color color;
+
+  // GRADIENT
+  /// {@template x_containers.docs.gradient}
+  /// An optional gradient to color the box.
+  ///
+  /// If it is not null, then it overrides the color.
+  /// {@endtemplate}
+  final Gradient gradient;
+
+  // SHADOW COLOR
+  /// {@template x_containers.docs.shadowColor}
+  /// The color of the shadow of the box.
+  /// {@endtemplate}
+  final Color shadowColor;
+
+  // ENABLE SHADOW
+  /// {@template x_containers.docs.enableShadow}
+  /// Whether the box should have a shadow.
+  ///
+  /// Defaults to [xTheme.enableShadow].
+  /// {@endtemplate}
+  final bool enableShadow;
+
+  // LAYOUT ======================================================================
+
+  // ALIGNMENT
+  /// {@template x_containers.docs.alignment}
+  /// An optional alignment setting.
+  ///
+  /// Defaults to [xTheme.alignment].
+  /// {@endtemplate}
+  final Alignment alignment;
+
+  // PADDING
+  /// {@template x_containers.docs.padding}
+  /// An optional padding setting.
+  ///
+  /// Defaults to [xTheme.padding].
+  /// {@endtemplate}
+  final EdgeInsets padding;
+
+  // MARGIN
+  /// {@template x_containers.docs.margin}
+  /// An optional margin setting.
+  ///
+  /// Defaults to [xTheme.margin].
+  /// {@endtemplate}
+  final EdgeInsets margin;
+
+  // BORDER RADIUS
+  /// {@template x_containers.docs.borderRadius}
+  /// An optional border radius setting.
+  ///
+  /// Defaults to [xTheme.borderRadius].
+  /// {@endtemplate}
+  final BorderRadius borderRadius;
+
+  // BORDER DECORATION
+  /// {@template x_containers.docs.borderDecoration}
+  /// An optional box border setting.
+  ///
+  /// Defaults to [xTheme.borderDecoration].
+  /// {@endtemplate}
+  final Border borderDecoration;
+
+  // BOX CONSTRAINTS
+  /// {@template x_containers.docs.constraints}
+  /// An optional BoxConstraints setting.
+  /// {@endtemplate}
+  final BoxConstraints constraints;
+
+  // WIDTH
+  /// {@template x_containers.docs.width}
+  /// The optional horizontal extent of the container.
+  /// {@endtemplate}
+  final double width;
+
+  // HEIGHT
+  /// {@template x_containers.docs.height}
+  /// The optional vertical extent of the container.
+  /// {@endtemplate}
+  final double height;
+
+  // INTERACTIVITY =============================================================
+
+  // ON TAP
+  /// {@template x_containers.docs.onTap}
+  /// An optional behavior when the container is tapped on.
+  /// {@endtemplate}
+  final void Function()? onTap;
+
+  // ON LONG PRESS
+  /// {@template x_containers.docs.onLongPress}
+  /// An optional behavior when the container is pressed on for a longer time.
+  /// {@endtemplate}
+  final void Function()? onLongPress;
+
+  // SPLASH COLOR
+  /// {@template x_containers.docs.splashColor}
+  /// A splash color to paint when the container is tapped.
+  /// {@endtemplate}
+  final Color? splashColor;
+
+  // ENABLE SPLASH
+  /// {@template x_containers.docs.enableSplash}
+  /// Whether the container should "splash" when tapped on.
+  ///
+  /// Defaults to [xTheme.enableSplash].
+  /// {@endtemplate}
+  final bool? enableSplash;
+
+  // CONSTRUCTOR ===============================================================
+
+  Documentation._internal(
+    this.child,
+    this.color,
+    this.gradient,
+    this.shadowColor,
+    this.enableShadow,
+    this.alignment,
+    this.padding,
+    this.margin,
+    this.borderRadius,
+    this.borderDecoration,
+    this.constraints,
+    this.width,
+    this.height,
+    this.onTap,
+    this.onLongPress,
+    this.splashColor,
+    this.enableSplash,
+    this.title,
+    this.content,
+    this.leading,
+    this.trailing,
+  );
+}

--- a/lib/src/settings/x_theme.dart
+++ b/lib/src/settings/x_theme.dart
@@ -7,8 +7,8 @@ import "../../x_containers.dart";
 
 /// A singleton managing the default settings of the XContainer package.
 ///
-/// It allows to change the default properties of all the widgets in
-/// this package at once.
+/// It allows to change the default properties of all the widgets in this
+/// package at once.
 /// The default colors can be configured as well; if they are not set, the theme
 /// colors are used.
 ///
@@ -191,61 +191,59 @@ class XTheme {
     ExpansionTileThemeData? expansionTileTheme,
   }) {
     final bool isDarkMode = mode == ThemeMode.dark;
-    final Color textColor = isDarkMode ? Colors.white : Colors.black87;
+    final Color textColor = isDarkMode ? Colors.white : Colors.black;
+
     // Custom [TextTheme] is broken and leads to crashes when switching between themes.
-    // final TextTheme defaultTextTheme = const TextTheme().merge(TextTheme(
-    //   // TITLE MEDIUM
-    //   titleLarge: const TextStyle().merge(const TextStyle(
-    //     fontSize: 24,
-    //     fontWeight: FontWeight.w600,
-    //     letterSpacing: 0.15,
-    //     inherit: true,
-    //   )),
-    //   // TITLE MEDIUM
-    //   titleMedium: const TextStyle().merge(const TextStyle(
-    //     fontSize: 20,
-    //     fontWeight: FontWeight.w600,
-    //     letterSpacing: 0.15,
-    //     inherit: true,
-    //   )),
-    //   // TITLE SMALL
-    //   titleSmall: const TextStyle().merge(const TextStyle(
-    //     fontSize: 16,
-    //     fontWeight: FontWeight.w600,
-    //     letterSpacing: 0.15,
-    //     inherit: true,
-    //   )),
-    //   // BODY MEDIUM
-    //   bodyLarge: const TextStyle().merge(const TextStyle(
-    //     fontSize: 18,
-    //     fontWeight: FontWeight.w400,
-    //     letterSpacing: 0.15,
-    //     inherit: true,
-    //   )),
-    //   // BODY MEDIUM
-    //   bodyMedium: const TextStyle().merge(const TextStyle(
-    //     fontSize: 15,
-    //     fontWeight: FontWeight.w400,
-    //     letterSpacing: 0.15,
-    //     inherit: true,
-    //   )),
-    //   // BODY SMALL
-    //   bodySmall: const TextStyle().merge(const TextStyle(
-    //     fontSize: 12,
-    //     fontWeight: FontWeight.w400,
-    //     letterSpacing: 0.15,
-    //     inherit: true,
-    //   )),
-    // )).apply(
+    final TextTheme defaultTextTheme = Typography()
+        .englishLike
+        .copyWith(
+          // TITLE LARGE
+          titleLarge: const TextStyle().copyWith(
+            fontSize: 24,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.15,
+          ),
+          // TITLE MEDIUM
+          titleMedium: const TextStyle().copyWith(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.15,
+          ),
+          // TITLE SMALL
+          titleSmall: const TextStyle().copyWith(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.15,
+          ),
+          // BODY LARGE
+          bodyLarge: const TextStyle().copyWith(
+            fontSize: 18,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.15,
+          ),
+          // BODY MEDIUM
+          bodyMedium: const TextStyle().copyWith(
+            fontSize: 15,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.15,
+          ),
+          // BODY SMALL
+          bodySmall: const TextStyle().copyWith(
+            fontSize: 12,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.15,
+          ),
+        )
+        .apply(
+          bodyColor: textColor,
+          displayColor: textColor,
+          decorationColor: textColor,
+        );
+    // final TextTheme defaultTextTheme = const TextTheme().apply(
     //   bodyColor: textColor,
     //   displayColor: textColor,
     //   decorationColor: textColor,
     // );
-    final TextTheme defaultTextTheme = const TextTheme().apply(
-      bodyColor: textColor,
-      displayColor: textColor,
-      decorationColor: textColor,
-    );
 
     final ThemeData res = isDarkMode ? ThemeData.dark() : ThemeData.light();
 
@@ -316,8 +314,8 @@ class XTheme {
       toggleableActiveColor: toggleableActiveColor,
       // TEXT THEME ------------------------------------------------------------
       typography: typography,
-      textTheme: textTheme ?? defaultTextTheme,
-      primaryTextTheme: primaryTextTheme,
+      textTheme: defaultTextTheme.merge(textTheme),
+      primaryTextTheme: defaultTextTheme.merge(primaryTextTheme),
       // OTHER -----------------------------------------------------------------
       iconTheme: iconTheme ??
           const IconThemeData().copyWith(
@@ -359,7 +357,7 @@ class XTheme {
       drawerTheme: drawerTheme ??
           (backgroundAlt == null
               ? null
-              : DrawerThemeData(
+              : const DrawerThemeData().copyWith(
                   backgroundColor: backgroundAlt,
                 )),
       elevatedButtonTheme: elevatedButtonTheme,
@@ -376,22 +374,20 @@ class XTheme {
       switchTheme: switchTheme,
       tabBarTheme: tabBarTheme,
       textButtonTheme: textButtonTheme ??
-          TextButtonThemeData(
-            // If there are no background color nor alternate background color,
-            // the style is not changed;
-            // Otherwise, it is set to match the alternate background color (or the
-            // regular background color if there is none.
-            style: background == null && backgroundAlt == null
-                ? null
-                : const ButtonStyle().copyWith(
+          (background == null && backgroundAlt == null
+              ? null
+              : TextButtonThemeData(
+                  // If there are no background color nor alternate background color,
+                  // the style is not changed;
+                  // Otherwise, it is set to match the alternate background color (or the
+                  // regular background color if there is none.
+                  style: const ButtonStyle().copyWith(
                     backgroundColor: MaterialStateProperty.all<Color>(
                         backgroundAlt ?? background!),
                     foregroundColor:
                         MaterialStateProperty.all<Color>(textColor),
-                    textStyle: MaterialStateProperty.all<TextStyle?>(
-                        defaultTextTheme.bodyMedium),
                   ),
-          ),
+                )),
       textSelectionTheme: textSelectionTheme ??
           (secondary == null
               ? null

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -1,3 +1,4 @@
 export "x_card.dart";
+export "x_list_tile.dart";
 export "x_container.dart";
 export "x_ink_container.dart";

--- a/lib/src/widgets/x_card.dart
+++ b/lib/src/widgets/x_card.dart
@@ -14,8 +14,8 @@ class XCard extends StatelessWidget {
   /// The title of the card.
   final Widget title;
 
-  /// The (optional) subtitle of the card.
-  final Widget? subtitle;
+  /// The (optional) content of the card.
+  final Widget? content;
 
   /// An (optional) widget to be displayed on the right of the card.
   final Widget? trailing;
@@ -77,11 +77,21 @@ class XCard extends StatelessWidget {
   // CONSTRUCTOR ===============================================================
 
   /// Returns an instance of [XCard] matching the given parameters.
+  ///
+  /// PARAMETERS:
+  ///
+  /// > - [title], [content], [leading] and [trailing] are widgets.
+  /// > - [color], [margin] and [padding] work as usual.
+  /// > - [enableShadow] decides whether the card casts a shadow.
+  /// > - [borderRadius] describes the intensity of the curvature of the corners.
+  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
+  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [onTap] is a function called when the card is tapped.
   const XCard({
     Key? key,
-    this.leading,
     required this.title,
-    this.subtitle,
+    this.content,
+    this.leading,
     this.trailing,
     this.color,
     this.enableShadow,
@@ -125,15 +135,15 @@ class XCard extends StatelessWidget {
                   child: title,
                 ),
                 Visibility(
-                  visible: subtitle != null,
+                  visible: content != null,
                   child: SizedBox(height: _density / _densityRatio),
                 ),
                 Visibility(
-                  visible: subtitle != null,
+                  visible: content != null,
                   child: DefaultTextStyle(
                     style: Theme.of(context).textTheme.bodySmall ??
                         const TextStyle(),
-                    child: subtitle ?? const SizedBox(),
+                    child: content ?? const SizedBox(),
                   ),
                 ),
               ],

--- a/lib/src/widgets/x_card.dart
+++ b/lib/src/widgets/x_card.dart
@@ -22,20 +22,16 @@ class XCard extends StatelessWidget {
 
   // COLOR ---------------------------------------------------------------------
 
-  /// The color of the card.
+  /// {@macro x_containers.docs.color}
   final Color? color;
 
-  /// Whether the card should cast a shadow.
-  ///
-  /// Defaults to [xTheme.enableShadow].
+  /// {@macro x_containers.docs.enableShadow}
   final bool? enableShadow;
   bool get _enableShadow => enableShadow ?? xTheme.enableShadow;
 
   // LAYOUT --------------------------------------------------------------------
 
-  /// An optional BorderRadius setting.
-  ///
-  /// Defaults to [xTheme.borderRadius].
+  /// {@macro x_containers.docs.borderRadius}
   final BorderRadius? borderRadius;
   BorderRadius get _borderRadius => borderRadius ?? xTheme.borderRadius;
 
@@ -50,13 +46,11 @@ class XCard extends StatelessWidget {
         vertical: _density / _densityRatio,
       );
 
-  /// An optional margin setting.
-  ///
-  /// The default margin is computed from the density value.
+  /// {@macro x_containers.docs.margin}
   final EdgeInsetsGeometry? margin;
   EdgeInsetsGeometry get _margin => margin ?? xTheme.margin;
 
-  /// A double managing the padding of the card.
+  /// A double managing the padding between the elements of the card.
   ///
   /// It has an impact on how close the children fit within the card.
   final double? density;
@@ -71,8 +65,11 @@ class XCard extends StatelessWidget {
 
   // INTERACTIVITY -------------------------------------------------------------
 
-  /// An (optional) functional specifying the behavior of the card when tapped.
+  /// {@macro x_containers.docs.onTap}
   final void Function()? onTap;
+
+  /// {@macro x_containers.docs.onLongPress}
+  final void Function()? onLongPress;
 
   // CONSTRUCTOR ===============================================================
 
@@ -101,6 +98,7 @@ class XCard extends StatelessWidget {
     this.density,
     this.densityRatio,
     this.onTap,
+    this.onLongPress,
   }) : super(key: key);
 
   // BUILD =====================================================================
@@ -109,53 +107,18 @@ class XCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return XInkContainer(
       margin: _margin,
-      padding: _padding,
       borderRadius: _borderRadius,
       onTap: onTap,
       color: color ?? Theme.of(context).cardColor,
       enableShadow: _enableShadow,
-      child: Row(
-        children: [
-          // LEADING -----------------------------------------------------------
-          leading ?? const SizedBox(),
-
-          // SPACING -----------------------------------------------------------
-          SizedBox(width: leading == null ? 0 : _density),
-
-          // MAIN BOX ----------------------------------------------------------
-          Expanded(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                DefaultTextStyle(
-                  textAlign: TextAlign.start,
-                  style: Theme.of(context).textTheme.bodyMedium ??
-                      const TextStyle(),
-                  child: title,
-                ),
-                Visibility(
-                  visible: content != null,
-                  child: SizedBox(height: _density / _densityRatio),
-                ),
-                Visibility(
-                  visible: content != null,
-                  child: DefaultTextStyle(
-                    style: Theme.of(context).textTheme.bodySmall ??
-                        const TextStyle(),
-                    child: content ?? const SizedBox(),
-                  ),
-                ),
-              ],
-            ),
-          ),
-
-          // SPACING -----------------------------------------------------------
-          SizedBox(width: trailing == null ? 0 : _density),
-
-          // TRAILING ----------------------------------------------------------
-          trailing ?? const SizedBox(),
-        ],
+      child: XListTile(
+        title: title,
+        content: content,
+        leading: leading,
+        trailing: trailing,
+        margin: _padding,
+        density: density,
+        densityRatio: densityRatio,
       ),
     );
   }

--- a/lib/src/widgets/x_container.dart
+++ b/lib/src/widgets/x_container.dart
@@ -8,72 +8,56 @@ class XContainer extends StatelessWidget {
 
   // COLORS --------------------------------------------------------------------
 
-  /// The main color of the box.
+  /// {@macro x_containers.docs.color}
   final Color? color;
 
-  /// An optional gradient to color the box.
-  ///
-  /// If it is not null, the it overrides the color.
+  /// {@macro x_containers.docs.gradient}
   final Gradient? gradient;
   Gradient? get _gradient => gradient;
 
-  /// The color of the shadow of the box.
+  /// {@macro x_containers.docs.shadowColor}
   final Color? shadowColor;
 
-  /// Whether the box should have a shadow.
-  ///
-  /// Defaults to [xTheme.enableShadow].
+  /// {@macro x_containers.docs.enableShadow}
   final bool? enableShadow;
   bool get _enableShadow => enableShadow ?? xTheme.enableShadow;
 
   // LAYOUT --------------------------------------------------------------------
 
-  /// An optional alignment setting.
-  ///
-  /// Defaults to [xTheme.alignment].
+  /// {@macro x_containers.docs.alignment}
   final AlignmentGeometry? alignment;
   AlignmentGeometry? get _alignment => alignment ?? xTheme.alignment;
 
-  /// An optional padding setting.
-  ///
-  /// Defaults to [xTheme.padding].
+  /// {@macro x_containers.docs.padding}
   final EdgeInsetsGeometry? padding;
   EdgeInsetsGeometry get _padding => padding ?? xTheme.padding;
 
-  /// An optional margin setting.
-  ///
-  /// Defaults to [xTheme.margin].
+  /// {@macro x_containers.docs.margin}
   final EdgeInsetsGeometry? margin;
   EdgeInsetsGeometry get _margin => margin ?? xTheme.margin;
 
-  /// An optional BorderRadius setting.
-  ///
-  /// Defaults to [xTheme.borderRadius].
+  /// {@macro x_containers.docs.borderRadius}
   final BorderRadius? borderRadius;
   BorderRadius get _borderRadius => borderRadius ?? xTheme.borderRadius;
 
-  /// An optional BorderDecoration setting.
-  ///
-  /// Defaults to [xTheme.borderDecoration].
+  /// {@macro x_containers.docs.borderDecoration}
   final BoxBorder? borderDecoration;
   BoxBorder? get _borderDecoration =>
       borderDecoration ?? xTheme.borderDecoration;
 
-  /// An optional BoxConstraints setting.
-  ///
-  /// If not specified, there is no constraint.
+  /// {@macro x_containers.docs.constraints}
   final BoxConstraints? constraints;
   BoxConstraints? get _constraints => constraints;
 
-  /// The optional horizontal extent of the container.
+  /// {@macro x_containers.docs.width}
   final double? width;
   double? get _width => width;
 
-  /// The optional vertical extent of the container
+  /// {@macro x_containers.docs.height}
   final double? height;
   double? get _height => height;
 
-  /// The child to build in the box.
+  /// {@macro x_containers.docs.child}
   final Widget? child;
   Widget? get _child => child;
 

--- a/lib/src/widgets/x_container.dart
+++ b/lib/src/widgets/x_container.dart
@@ -86,7 +86,7 @@ class XContainer extends StatelessWidget {
     this.color,
     this.gradient,
     this.shadowColor,
-    this.enableShadow = true,
+    this.enableShadow,
     // shape
     this.borderRadius,
     this.borderDecoration,

--- a/lib/src/widgets/x_ink_container.dart
+++ b/lib/src/widgets/x_ink_container.dart
@@ -6,7 +6,7 @@ import "../../x_containers.dart";
 ///
 /// It has the same properties as a regular container with the exception the some
 /// decorations can be set directly without using a [BoxDecoration].
-/// Obviously, these decorations will be overridden if the property [decoration]
+/// However, these decorations will be overridden if the property [decoration]
 /// is provided.
 ///
 /// On top of the container, a ink behavior is implemented to allow tapping with
@@ -16,86 +16,71 @@ class XInkContainer extends StatelessWidget {
 
   // COLORS --------------------------------------------------------------------
 
-  /// The main color of the box.
+  /// {@macro x_containers.docs.color}
   final Color? color;
 
-  /// An optional gradient to color the box.
-  ///
-  /// If it is not null, then it overrides the color.
+  /// {@macro x_containers.docs.gradient}
   final Gradient? gradient;
   Gradient? get _gradient => gradient;
 
-  /// The color of the shadow of the box.
+  /// {@macro x_containers.docs.shadowColor}
   final Color? shadowColor;
 
-  /// Whether the box should have a shadow.
-  ///
-  /// Defaults to [xTheme.enableShadow].
+  /// {@macro x_containers.docs.enableShadow}
   final bool? enableShadow;
   bool get _enableShadow => enableShadow ?? xTheme.enableShadow;
 
   // LAYOUT --------------------------------------------------------------------
 
-  /// An optional alignment setting.
-  ///
-  /// Defaults to [xTheme.alignment].
+  /// {@macro x_containers.docs.alignment}
   final AlignmentGeometry? alignment;
   AlignmentGeometry? get _alignment => alignment ?? xTheme.alignment;
 
-  /// An optional padding setting.
-  ///
-  /// Defaults to [xTheme.padding].
+  /// {@macro x_containers.docs.padding}
   final EdgeInsetsGeometry? padding;
   EdgeInsetsGeometry get _padding => padding ?? xTheme.padding;
 
-  /// An optional margin setting.
-  ///
-  /// Defaults to [xTheme.margin].
+  /// {@macro x_containers.docs.margin}
   final EdgeInsetsGeometry? margin;
   EdgeInsetsGeometry get _margin => margin ?? xTheme.margin;
 
-  /// An optional BorderRadius setting.
-  ///
-  /// Defaults to [xTheme.borderRadius].
+  /// {@macro x_containers.docs.borderRadius}
   final BorderRadius? borderRadius;
   BorderRadius get _borderRadius => borderRadius ?? xTheme.borderRadius;
 
-  /// An optional BorderDecoration setting.
-  ///
-  /// Defaults to [xTheme.borderDecoration].
+  /// {@macro x_containers.docs.borderDecoration}
   final BoxBorder? borderDecoration;
   BoxBorder? get _borderDecoration =>
       borderDecoration ?? xTheme.borderDecoration;
 
-  /// An optional BoxConstraints setting.
-  ///
-  /// If not specified, there is no constraint.
+  /// {@macro x_containers.docs.constraints}
   final BoxConstraints? constraints;
   BoxConstraints? get _constraints => constraints;
 
-  /// The optional horizontal extent of the container.
+  /// {@macro x_containers.docs.width}
   final double? width;
   double? get _width => width;
 
-  /// The optional vertical extent of the container
+  /// {@macro x_containers.docs.height}
   final double? height;
   double? get _height => height;
 
-  /// The child to build in the box.
+  /// {@macro x_containers.docs.child}
   final Widget? child;
   Widget? get _child => child;
 
   // INTERACTIVITY -------------------------------------------------------------
 
-  /// An optional behavior when the container is tapped on.
+  /// {@macro x_containers.docs.onTap}
   final void Function()? onTap;
 
-  /// A splash color to paint when the container is tapped.
+  /// {@macro x_containers.docs.onLongPress}
+  final void Function()? onLongPress;
+
+  /// {@macro x_containers.docs.splashColor}
   final Color? splashColor;
 
-  /// Whether the container should "splash" when tapped on.
-  ///
-  /// Defaults to [xTheme.enableSplash].
+  /// {@macro x_containers.docs.enableSplash}
   final bool? enableSplash;
   bool get _enableSplash => enableSplash ?? xTheme.enableSplash;
 
@@ -118,6 +103,7 @@ class XInkContainer extends StatelessWidget {
     this.borderDecoration,
     this.enableShadow,
     this.onTap,
+    this.onLongPress,
     this.enableSplash,
     this.splashColor,
   }) : super(key: key);

--- a/lib/src/widgets/x_list_tile.dart
+++ b/lib/src/widgets/x_list_tile.dart
@@ -1,0 +1,144 @@
+import "package:flutter/material.dart";
+
+import "../../x_containers.dart";
+
+/// A custom [ListTile]-style widget.
+///
+/// It was created to provide a simpler tile alternative to [ListTile] and
+/// overcome the issue of the [leading] and [trailing] widgets not being
+/// properly aligned.
+class XListTile extends StatelessWidget {
+  // VARIABLES =================================================================
+
+  // CHILDREN ------------------------------------------------------------------
+
+  /// An (optional) widget to be displayed on the left of the card.
+  final Widget? leading;
+
+  /// The title of the card.
+  final Widget title;
+
+  /// The (optional) content of the card.
+  final Widget? content;
+
+  /// An (optional) widget to be displayed on the right of the card.
+  final Widget? trailing;
+
+  // LAYOUT --------------------------------------------------------------------
+
+  /// An optional margin setting.
+  ///
+  /// The default margin is computed from the density value and does NOT use the
+  /// [xTheme.padding] property.
+  final EdgeInsetsGeometry? margin;
+  EdgeInsetsGeometry get _margin =>
+      margin ??
+      EdgeInsets.symmetric(
+        horizontal: _density,
+        vertical: _density / _densityRatio,
+      );
+
+  /// A double managing the padding of the card.
+  ///
+  /// It has an impact on how close the children fit within the card.
+  final double? density;
+  double get _density => density ?? xTheme.paddingValue;
+
+  /// The ratio of horizontal density over vertical density.
+  ///
+  /// Increasing it will decrease the vertical padding if there is some.
+  /// Defaults to [xTheme.densityRatio].
+  final double? densityRatio;
+  double get _densityRatio => densityRatio ?? xTheme.densityRatio;
+
+  // INTERACTIVITY -------------------------------------------------------------
+
+  /// {@macro x_containers.docs.onTap}
+  final void Function()? onTap;
+
+  /// {@macro x_containers.docs.onLongPress}
+  final void Function()? onLongPress;
+
+  // CONSTRUCTOR ===============================================================
+
+  /// Returns an instance of [XCard] matching the given parameters.
+  ///
+  /// PARAMETERS:
+  ///
+  /// > - [title], [content], [leading] and [trailing] are widgets.
+  /// > - [margin] works as usual, but by default it is computed from [density] and [densityRatio].
+  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
+  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [onTap] and [onLongPress] are functions called when the card is tapped or pressed for a longer time.
+  const XListTile({
+    Key? key,
+    required this.title,
+    this.content,
+    this.leading,
+    this.trailing,
+    this.margin,
+    this.density,
+    this.densityRatio,
+    this.onTap,
+    this.onLongPress,
+  }) : super(key: key);
+
+  // BUILD =====================================================================
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Padding(
+        padding: _margin,
+        child: Row(
+          children: [
+            // LEADING -----------------------------------------------------------
+            leading ?? const SizedBox(),
+
+            // SPACING -----------------------------------------------------------
+            SizedBox(width: leading == null ? 0 : _density),
+
+            // MAIN BOX ----------------------------------------------------------
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  DefaultTextStyle(
+                    style: const TextStyle()
+                        .merge(Theme.of(context).textTheme.titleMedium),
+                    textAlign: TextAlign.start,
+                    child: title,
+                  ),
+                  Visibility(
+                    visible: content != null,
+                    child: SizedBox(height: _density / _densityRatio),
+                  ),
+                  Visibility(
+                    visible: content != null,
+                    child: DefaultTextStyle(
+                      style: const TextStyle()
+                          .merge(Theme.of(context).textTheme.bodyMedium),
+                      child: content ?? const SizedBox(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // SPACING -----------------------------------------------------------
+            SizedBox(width: trailing == null ? 0 : _density),
+
+            // TRAILING ----------------------------------------------------------
+            trailing ?? const SizedBox(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // WIDGETS ===================================================================
+
+}

--- a/lib/x_containers.dart
+++ b/lib/x_containers.dart
@@ -1,4 +1,4 @@
-library x_container;
+library x_containers;
 
 import "src/settings/settings.dart";
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,50 @@
+# COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+TARGET_MAX_CHAR_NUM=20
+## Show help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")-1); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+
+## Checks whether the version number and the last changelog-ed version match.
+check-version:
+	@echo "\n>>> CHECKING VERSION:"
+	@echo "To implement"
+
+## Analyzes the contents of the lib folder.
+analyze:
+	@echo "\n>>> ANALYZING LIB/ CODE:"
+	@flutter pub get
+	@flutter analyze lib/
+
+## Formats the code to match flutter's conventions
+format:
+	@echo "\n>>> FORMATTING PROJECT CODE:"
+	@flutter format .
+
+## Analyzes and format the code to make sure of the quality.
+pre-commit:
+	@echo "\n>>> RUNNING PRE-COMMIT CHECKS:"
+	@make format
+	@make analyze
+	@make check-version
+
+## Publishes the code to pub.dev
+publish:
+	@echo "\n>>> PUBLISHING TO PUB.DEV:"
+	@dart pub publish

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.0.3-dev.1
+version: 1.1.0
 homepage: https://github.com/XLhinares/x_containers
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  lint: ^1.10.0
+  lint: ^2.0.1
   flutter_test:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/XLhinares/x_containers
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.0.2
+version: 1.0.3-dev.1
 homepage: https://github.com/XLhinares/x_containers
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.1.1
+version: 1.2.0
 homepage: https://github.com/XLhinares/x_containers
 
 environment:


### PR DESCRIPTION
## 1.2.0

- `ADDED`: [XListTile] as a way to have a box-less reusable tile layout.
- `ADDED`: A preset [TextTheme] to [xTheme.getTheme] that can be fully or partially overridden.
- `CHANGED`: [XCard] and [XSnackbar] use [XListTile].
- `CHANGED`: The documentation which is now handled in part by macros.
- `CHANGED`: The example to showcase changing the text theme through [xTheme].

- `BREAKING`: [XSnackbar] doesn't use the [titleStyle] and [contentStyle] properties which are handled by the text theme.