### PR TITLE
:twisted_rightwards_arrows: Update to v1.2.2

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,1 +1,2 @@
 assets/
+doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,101 +1,108 @@
+## 1.2.2
+
+- :construction_worker: Switched to emojis in the CHANGELOG (matching the gitmoji.dev guide).
+- :construction_worker: Add a script to check the version number.
+- :sparkles: Added `XListTile.text` and `XCard.text` to not have to wrap strings with a `Text` widget every time.
+- :recycle: Changed the example to feature `XListTile.text`.
+ 
 ## 1.2.1
 
-- `FIXED`: The [XCard] issue where the padding was stacked with [xTheme.padding].
+- :bug: The `XCard` issue where the padding was stacked with `xTheme.padding`.
 
 ## 1.2.0
 
-- `ADDED`: [XListTile] as a way to have a box-less reusable tile layout.
-- `ADDED`: A preset [TextTheme] to [xTheme.getTheme] that can be fully or partially overridden.
-- `CHANGED`: [XCard] and [XSnackbar] use [XListTile].
-- `CHANGED`: The documentation which is now handled in part by macros.
-- `CHANGED`: The example to showcase changing the text theme through [xTheme].
+- :sparkles: `XListTile` as a way to have a box-less reusable tile layout.
+- :sparkles: A preset `TextTheme` to `xTheme.getTheme` that can be fully or partially overridden.
+- :recycle: Changed `XCard` and `XSnackbar` use `XListTile`.
+- :recycle: Changed the documentation which is now handled in part by macros.
+- :recycle: Changed the example to showcase changing the text theme through `xTheme`.
 
-- `BREAKING`: [XSnackbar] doesn't use the [titleStyle] and [contentStyle] properties which are handled by the text theme.
+- :boom: `XSnackbar` doesn't use the `titleStyle` and `contentStyle` properties which are handled by the text theme.
 
 ## 1.1.1
 
-- `CHANGED`: Fixed library name (from `x_container` to `x_containers`).
+- :recycle: Fixed library name (from `x_container` to `x_containers`).
 
 ## 1.1.0
 
-- `ADDED`: a makefile containing a few utility commands.
-- `IMPROVED`: The documentation comments on the class constructors.
-- `IMPROVED`: The [XDialog] buttons turn invisible if their label is set to [null].
+- :sparkles: a makefile containing a few utility commands.
+- :zap: Improved The documentation comments on the class constructors.
+- :zap: Improved The `XDialog` buttons turn invisible if their label is set to `null`.
 
-- `BREAKING`: In [XSnackbar], the field [message] is renamed to [content] to match the naming of other classes.
-- `BREAKING`: In [XCard], the field [subtitle] is renamed to [content] to match the naming of other classes.
+- :boom: In `XSnackbar`, the field `message` is renamed to `content` to match the naming of other classes.
+- :boom: In `XCard`, the field `subtitle` is renamed to `content` to match the naming of other classes.
 
-- `CHANGED`: The example to match the breaking changes.
+- :recycle: Changed the example to match the breaking changes.
 
 ## 1.0.3-dev.1
 
-- `IMPROVED`: The README for even better legibility.
-- `IMPROVED`: Using asset image from github.
+- :zap: Improved The README for even better legibility.
+- :zap: Improved Using asset image from github.
 
 ## 1.0.2
 
-- `ADDED`: An XContainers preview image for the README.
-- `IMPROVED`: The README structure for legibility.
-- `IMPROVED`: The CHANGELOG because it wasn't displayed properly on pub.dev.
-- `REFACTORED`: The code using `flutter format .`.
+- :sparkles: An XContainers preview image for the README.
+- :zap: Improved the README structure for legibility.
+- :zap: Improved the CHANGELOG because it wasn't displayed properly on pub.dev.
+- :truck: The code using `flutter format .`.
 
 ## 1.0.1
 
-- `IMPROVED`: Extensive examples of the use of the different XContainers.
+- :zap: Added extensive examples of the use of the different XContainers.
 
 ## 1.0.0
 
-- `DELETED`: Uses of the `get` package, because it made XContainers not work with non-get apps. 
-- `DELETED`: [PhysicalModel] from [XContainer] and [XInkContainer] since the [Material] widget handles the same properties. 
-- `DELETED`: Temporarily got rid of the custom [TextTheme] generation by the [xTheme] object, as it caused issues during theme changes.
-- `IMPROVED`: Generation of a [ThemeData] by the [xTheme] object.
+- :fire: Deleted uses of the `get` package, because it made XContainers not work with non-get apps. 
+- :fire: Deleted `PhysicalModel` from `XContainer` and `XInkContainer` since the `Material` widget handles the same properties. 
+- :fire: Temporarily got rid of the custom `TextTheme` generation by the `xTheme` object, as it caused issues during theme changes.
+- :zap: Improved generation of a `ThemeData` by the `xTheme` object.
 
 ## 0.2.3
 
-- `REFACTORED`: Using relative imports.
-- `REFACTORED`: Non-top-level code has been moved to `lib/src/`.
-- `ADDED`: A description of how to use `CHANGELOG.md`.
-- `IMPROVED`: `README.md` to be more clear and match some updates.
+- :truck: Switched to using relative imports.
+- :truck: Non-top-level code has been moved to `lib/src/`.
+- :sparkles: Added a description of how to use `CHANGELOG.md`.
+- :zap: Improved `README.md` to be more clear and match some updates.
 
 ## 0.2.2
 
-- `CHANGED`: [XContainer] use a physical model for better shadows.
-- `CHANGED`: [XSnackBar] now has a [maxWidth] attribute.
+- :recycle: Changed `XContainer` use a physical model for better shadows.
+- :recycle: Changed `XSnackBar` now has a `maxWidth` attribute.
 
 ## 0.2.1
 
-- `CHANGED`: [ShadowContainer] becomes [XContainer].
-- `CHANGED`: [InkContainer] becomes [XInkContainer].
-- `CHANGED`: Input fields now have padding surrounding the contents in [xTheme.getTheme].
+- :recycle: Changed `ShadowContainer` becomes `XContainer`.
+- :recycle: Changed `InkContainer` becomes `XInkContainer`.
+- :recycle: Changed input fields now have padding surrounding the contents in `xTheme.getTheme`.
 
 ## 0.2.0
 
-- `ADDED`: Theme generator from a palette.
-- `IMPROVED`: XContainers now use context for colors which allows for smooth theme changes.
+- :sparkles: Added a theme generator from a palette.
+- :zap: XContainers now use context for colors which allows for smooth theme changes.
 
 ## 0.1.0
 
-- `CHANGED`: Versioning now use the first number for major versions, the second for minor and the third for fixes.
+- :recycle: Versioning now use the first number for major versions, the second for minor and the third for fixes.
 
 ## 0.0.3
 
-- `ADDED`: [XDialog].
-- `ADDED`: [XSnackbar]. 
-- `IMPROVED`: Some [XTheme] values and added support for [XDialog] and [XSnackbar].
-- `IMPROVED`: Example to include XDialog and XSnackbar.
-- `CHANGED`: [xPadding] variables have become static members of [XLayout].
+- :sparkles: Added `XDialog`.
+- :sparkles: Added `XSnackbar`. 
+- :zap: Improved some `XTheme` values and added support for `XDialog` and `XSnackbar`.
+- :zap: Improved the example to include XDialog and XSnackbar.
+- :recycle: Changed `xPadding` variables have become static members of `XLayout`.
 
 ## 0.0.2
 
-- `ADDED`: some default padding values.
-- `ADDED`: XLayout class to manage common layout features.
+- :sparkles: Added some default padding values.
+- :sparkles: Added `XLayout` class to manage common layout features.
 
 ## 0.0.1
 
-- `ADDED`: ShadowContainer.
-- `ADDED`: InkContainer.
-- `ADDED`: XCard.
-- `ADDED`: XTheme to manage the shared properties.
+- :sparkles: Added `ShadowContainer`.
+- :sparkles: Added `InkContainer`.
+- :sparkles: Added `XCard`.
+- :sparkles: Added `XTheme` to manage the shared properties.
 
 
 ## How to use
@@ -106,13 +113,13 @@ The content of the section should be a bullet point list, with each point starti
 
 Keywords:
 
-- `ADDED`: When you add a new feature or dependency.
-- `IMPROVED`: When you make some feature or code better.
-- `FIXED`: When you make a correction to the code.
-- `CHANGED`: When you switch some code for different code (for instance, if we decided to radically change the way the movies are displayed).
-- `DELETED`: When you remove some feature or code.
-- `REFACTORED`: When you change file names or a linting rule.
-- `BREAKING`: Any breaking change.
+- :sparkles: When you add a new feature or dependency.
+- :zap: Improved When you make some feature or code better.
+- :bug: When you make a correction to the code.
+- :recycle: When you switch some code for different code (for instance, if we decided to radically change the way the movies are displayed).
+- :fire: When you remove some feature or code.
+- :truck: When you change file names or a linting rule.
+- :boom: Any breaking change.
 
 ## WARNING
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- `FIXED`: The [XCard] issue where the padding was stacked with [xTheme.padding].
+
 ## 1.2.0
 
 - `ADDED`: [XListTile] as a way to have a box-less reusable tile layout.
@@ -104,6 +108,7 @@ Keywords:
 
 - `ADDED`: When you add a new feature or dependency.
 - `IMPROVED`: When you make some feature or code better.
+- `FIXED`: When you make a correction to the code.
 - `CHANGED`: When you switch some code for different code (for instance, if we decided to radically change the way the movies are displayed).
 - `DELETED`: When you remove some feature or code.
 - `REFACTORED`: When you change file names or a linting rule.

--- a/example/lib/widgets/x_card.dart
+++ b/example/lib/widgets/x_card.dart
@@ -8,16 +8,15 @@ class ExampleXCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return XCard(
+    return XCard.text(
       densityRatio: 1,
       margin: EdgeInsets.all(XLayout.paddingS),
       leading: Icon(
         Icons.check_circle,
         size: XLayout.paddingL,
       ),
-      title: const Text("This is an [XCard]."),
-      content:
-          const Text("It works similarly to a [ListTile] within a [Card]."),
+      title: "This is an [XCard].",
+      content: "It works similarly to a [ListTile] within a [Card].",
     );
   }
 }

--- a/lib/src/widgets/x_card.dart
+++ b/lib/src/widgets/x_card.dart
@@ -107,6 +107,7 @@ class XCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return XInkContainer(
       margin: _margin,
+      padding: EdgeInsets.zero,
       borderRadius: _borderRadius,
       onTap: onTap,
       color: color ?? Theme.of(context).cardColor,

--- a/lib/src/widgets/x_card.dart
+++ b/lib/src/widgets/x_card.dart
@@ -85,7 +85,7 @@ class XCard extends StatelessWidget {
   /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
   /// > - [onTap] is a function called when the card is tapped.
   const XCard({
-    Key? key,
+    super.key,
     required this.title,
     this.content,
     this.leading,
@@ -99,7 +99,48 @@ class XCard extends StatelessWidget {
     this.densityRatio,
     this.onTap,
     this.onLongPress,
-  }) : super(key: key);
+  });
+
+  /// Returns an instance of [XCard] matching the given parameters.
+  ///
+  /// PARAMETERS:
+  ///
+  /// > - [title], [content] are Strings.
+  /// > - [titleStyle] and [contentStyle] are the styles of [title] and [content].
+  /// > - [leading] and [trailing] are widgets.
+  /// > - [color], [margin] and [padding] work as usual.
+  /// > - [enableShadow] decides whether the card casts a shadow.
+  /// > - [borderRadius] describes the intensity of the curvature of the corners.
+  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
+  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [onTap] is a function called when the card is tapped.
+  XCard.text({
+    super.key,
+    required String title,
+    String? content,
+    TextStyle? titleStyle,
+    TextStyle? contentStyle,
+    this.leading,
+    this.trailing,
+    this.color,
+    this.enableShadow,
+    this.borderRadius,
+    this.margin,
+    this.padding,
+    this.density,
+    this.densityRatio,
+    this.onTap,
+    this.onLongPress,
+  })  : title = Text(
+          title,
+          style: titleStyle,
+        ),
+        content = content == null
+            ? null
+            : Text(
+                content,
+                style: titleStyle,
+              );
 
   // BUILD =====================================================================
 

--- a/lib/src/widgets/x_list_tile.dart
+++ b/lib/src/widgets/x_list_tile.dart
@@ -71,7 +71,7 @@ class XListTile extends StatelessWidget {
   /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
   /// > - [onTap] and [onLongPress] are functions called when the card is tapped or pressed for a longer time.
   const XListTile({
-    Key? key,
+    super.key,
     required this.title,
     this.content,
     this.leading,
@@ -81,7 +81,42 @@ class XListTile extends StatelessWidget {
     this.densityRatio,
     this.onTap,
     this.onLongPress,
-  }) : super(key: key);
+  });
+
+  /// Returns an instance of [XCard] matching the given parameters.
+  ///
+  /// PARAMETERS:
+  ///
+  /// > - [title] and [content] are Strings.
+  /// > - [titleStyle] and [contentStyle] are the styles of [title] and [content].
+  /// > - [leading] and [trailing] are widgets.
+  /// > - [margin] works as usual, but by default it is computed from [density] and [densityRatio].
+  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
+  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [onTap] and [onLongPress] are functions called when the card is tapped or pressed for a longer time.
+  XListTile.text({
+    super.key,
+    required String title,
+    String? content,
+    TextStyle? titleStyle,
+    TextStyle? contentStyle,
+    this.leading,
+    this.trailing,
+    this.margin,
+    this.density,
+    this.densityRatio,
+    this.onTap,
+    this.onLongPress,
+  })  : title = Text(
+          title,
+          style: titleStyle,
+        ),
+        content = content == null
+            ? null
+            : Text(
+                content,
+                style: contentStyle,
+              );
 
   // BUILD =====================================================================
 
@@ -139,6 +174,6 @@ class XListTile extends StatelessWidget {
     );
   }
 
-  // WIDGETS ===================================================================
+// WIDGETS ===================================================================
 
 }

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ help:
 ## Checks whether the version number and the last changelog-ed version match.
 check-version:
 	@echo "\n>>> CHECKING VERSION:"
-	@echo "To implement"
+	@./scripts/check_version.sh
 
 ## Analyzes the contents of the lib folder.
 analyze:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/XLhinares/x_containers
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/XLhinares/x_containers
 
 environment:

--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Author : Xavier Lhinares
+
+C='\033[0m'   #'0' is the "No Color" ANSI color code.
+R='\033[0;31m'   #'0;31' is Red's ANSI color code.
+G='\033[0;32m'   #'0;32' is Green's ANSI color code.
+
+# Retrieve the line containing the version number and parse it.
+VERSION_LINE=$(head -1 CHANGELOG.md);
+VERSION_NUMBER=$(echo "$VERSION_LINE" | grep -oP "\d+\.\d+\.\d+.*");
+
+# Compare it to the version number in pubspec.yaml
+OCCURRENCES=$(grep -c "$VERSION_NUMBER" pubspec.yaml);
+if [ "$OCCURRENCES" = 1 ]; then
+echo "${G}Version numbers are matching! (v$VERSION_NUMBER)$C";
+exit 0;
+else
+echo "${R}The version numbers do NOT match!$C";
+exit 2;
+fi;


### PR DESCRIPTION
## 1.2.2

- :construction_worker: Switched to emojis in the CHANGELOG (matching the gitmoji.dev guide).
- :construction_worker: Add a script to check the version number.
- :sparkles: Added `XListTile.text` and `XCard.text` to not have to wrap strings with a `Text` widget every time.
- :recycle: Changed the example to feature `XListTile.text`.