### PR TITLE
:twisted_rightwards_arrows: Update to v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.3
+
+- :sparkles: Added an "autoPad" constructor to `XListTile` and `XCard` that matches the external and internal padding.
+- :recycle: Replaced `density` and `densityRatio` properties by `internalHorizontalPadding` and `internalVerticalPadding`.
+- :recycle: Changed the example to feature internal padding on `XCard`.
+
 ## 1.2.2
 
 - :construction_worker: Switched to emojis in the CHANGELOG (matching the gitmoji.dev guide).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 1.2.3
 
 - :sparkles: Added an "autoPad" constructor to `XListTile` and `XCard` that matches the external and internal padding.
-- :recycle: Replaced `density` and `densityRatio` properties by `internalHorizontalPadding` and `internalVerticalPadding`.
 - :recycle: Changed the example to feature internal padding on `XCard`.
+
+- :boom: Replaced `density` and `densityRatio` properties by `internalHorizontalPadding` and `internalVerticalPadding` in `xTheme`, `XListTile` and `XCard`.
 
 ## 1.2.2
 

--- a/example/lib/widgets/x_card.dart
+++ b/example/lib/widgets/x_card.dart
@@ -9,7 +9,9 @@ class ExampleXCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return XCard.text(
-      densityRatio: 1,
+      internalHorizontalPadding: XLayout.paddingM,
+      internalVerticalPadding: XLayout.paddingXS,
+      padding: EdgeInsets.all(XLayout.paddingM),
       margin: EdgeInsets.all(XLayout.paddingS),
       leading: Icon(
         Icons.check_circle,

--- a/lib/src/settings/x_theme.dart
+++ b/lib/src/settings/x_theme.dart
@@ -21,11 +21,11 @@ class XTheme {
   /// The default value of the padding used.
   double paddingValue = 10;
 
-  /// The ratio of horizontal density over vertical density.
-  ///
-  /// Default value: 4.
-  /// Increasing it will increase the vertical padding.
-  double densityRatio = 2;
+  /// The default value of the internal horizontal padding of [XListTile].
+  double internalHorizontalPadding = XLayout.paddingS;
+
+  /// The default value of the internal vertical padding of [XListTile].
+  double internalVerticalPadding = XLayout.paddingS;
 
   /// The default padding value for all XContainers.
   ///

--- a/lib/src/widgets/x_card.dart
+++ b/lib/src/widgets/x_card.dart
@@ -39,29 +39,21 @@ class XCard extends StatelessWidget {
   ///
   /// The default padding is computed from the density value.
   final EdgeInsetsGeometry? padding;
-  EdgeInsetsGeometry get _padding =>
-      padding ??
-      EdgeInsets.symmetric(
-        horizontal: _density,
-        vertical: _density / _densityRatio,
-      );
+  EdgeInsetsGeometry get _padding => padding ?? xTheme.padding;
 
   /// {@macro x_containers.docs.margin}
   final EdgeInsetsGeometry? margin;
   EdgeInsetsGeometry get _margin => margin ?? xTheme.margin;
 
-  /// A double managing the padding between the elements of the card.
-  ///
-  /// It has an impact on how close the children fit within the card.
-  final double? density;
-  double get _density => density ?? xTheme.paddingValue;
+  /// A double managing the horizontal padding between the contents of card.
+  final double? internalHorizontalPadding;
+  double get _internalHorizontalPadding =>
+      internalHorizontalPadding ?? xTheme.internalHorizontalPadding;
 
-  /// The ratio of horizontal density over vertical density.
-  ///
-  /// Increasing it will decrease the vertical padding if there is some.
-  /// Defaults to [xTheme.densityRatio].
-  final double? densityRatio;
-  double get _densityRatio => densityRatio ?? xTheme.densityRatio;
+  /// A double managing the horizontal padding between the contents of card.
+  final double? internalVerticalPadding;
+  double get _internalVerticalPadding =>
+      internalVerticalPadding ?? xTheme.internalVerticalPadding;
 
   // INTERACTIVITY -------------------------------------------------------------
 
@@ -81,8 +73,7 @@ class XCard extends StatelessWidget {
   /// > - [color], [margin] and [padding] work as usual.
   /// > - [enableShadow] decides whether the card casts a shadow.
   /// > - [borderRadius] describes the intensity of the curvature of the corners.
-  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
-  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [internalHorizontalPadding] and [internalVerticalPadding] manage the spacing between the contents of the tile.
   /// > - [onTap] is a function called when the card is tapped.
   const XCard({
     super.key,
@@ -95,11 +86,38 @@ class XCard extends StatelessWidget {
     this.borderRadius,
     this.margin,
     this.padding,
-    this.density,
-    this.densityRatio,
+    this.internalHorizontalPadding,
+    this.internalVerticalPadding,
     this.onTap,
     this.onLongPress,
   });
+
+  /// Returns an instance of [XCard] matching the given parameters.
+  ///
+  /// The internal horizontal and vertical padding match the horizontal and vertical values of the margin.
+  ///
+  /// PARAMETERS:
+  ///
+  /// > - [title], [content], [leading] and [trailing] are widgets.
+  /// > - [color], [margin] and [padding] work as usual.
+  /// > - [enableShadow] decides whether the card casts a shadow.
+  /// > - [borderRadius] describes the intensity of the curvature of the corners.
+  /// > - [onTap] is a function called when the card is tapped.
+  XCard.autoPad({
+    super.key,
+    required this.title,
+    this.content,
+    this.leading,
+    this.trailing,
+    this.color,
+    this.enableShadow,
+    this.borderRadius,
+    this.margin,
+    required EdgeInsets this.padding,
+    this.onTap,
+    this.onLongPress,
+  })  : internalHorizontalPadding = padding.horizontal,
+        internalVerticalPadding = padding.vertical;
 
   /// Returns an instance of [XCard] matching the given parameters.
   ///
@@ -111,8 +129,7 @@ class XCard extends StatelessWidget {
   /// > - [color], [margin] and [padding] work as usual.
   /// > - [enableShadow] decides whether the card casts a shadow.
   /// > - [borderRadius] describes the intensity of the curvature of the corners.
-  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
-  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [internalHorizontalPadding] and [internalVerticalPadding] manage the spacing between the contents of the tile.
   /// > - [onTap] is a function called when the card is tapped.
   XCard.text({
     super.key,
@@ -127,8 +144,8 @@ class XCard extends StatelessWidget {
     this.borderRadius,
     this.margin,
     this.padding,
-    this.density,
-    this.densityRatio,
+    this.internalHorizontalPadding,
+    this.internalVerticalPadding,
     this.onTap,
     this.onLongPress,
   })  : title = Text(
@@ -159,8 +176,8 @@ class XCard extends StatelessWidget {
         leading: leading,
         trailing: trailing,
         margin: _padding,
-        density: density,
-        densityRatio: densityRatio,
+        internalHorizontalPadding: _internalHorizontalPadding,
+        internalVerticalPadding: _internalVerticalPadding,
       ),
     );
   }

--- a/lib/src/widgets/x_list_tile.dart
+++ b/lib/src/widgets/x_list_tile.dart
@@ -28,28 +28,19 @@ class XListTile extends StatelessWidget {
 
   /// An optional margin setting.
   ///
-  /// The default margin is computed from the density value and does NOT use the
-  /// [xTheme.padding] property.
+  /// The default value is that of [xTheme.padding].
   final EdgeInsetsGeometry? margin;
-  EdgeInsetsGeometry get _margin =>
-      margin ??
-      EdgeInsets.symmetric(
-        horizontal: _density,
-        vertical: _density / _densityRatio,
-      );
+  EdgeInsetsGeometry get _margin => margin ?? xTheme.padding;
 
-  /// A double managing the padding of the card.
-  ///
-  /// It has an impact on how close the children fit within the card.
-  final double? density;
-  double get _density => density ?? xTheme.paddingValue;
+  /// A double managing the horizontal padding between the contents of card.
+  final double? internalHorizontalPadding;
+  double get _internalHorizontalPadding =>
+      internalHorizontalPadding ?? xTheme.internalHorizontalPadding;
 
-  /// The ratio of horizontal density over vertical density.
-  ///
-  /// Increasing it will decrease the vertical padding if there is some.
-  /// Defaults to [xTheme.densityRatio].
-  final double? densityRatio;
-  double get _densityRatio => densityRatio ?? xTheme.densityRatio;
+  /// A double managing the horizontal padding between the contents of card.
+  final double? internalVerticalPadding;
+  double get _internalVerticalPadding =>
+      internalVerticalPadding ?? xTheme.internalVerticalPadding;
 
   // INTERACTIVITY -------------------------------------------------------------
 
@@ -67,8 +58,7 @@ class XListTile extends StatelessWidget {
   ///
   /// > - [title], [content], [leading] and [trailing] are widgets.
   /// > - [margin] works as usual, but by default it is computed from [density] and [densityRatio].
-  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
-  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [internalHorizontalPadding] and [internalVerticalPadding] manage the spacing between the contents of the tile.
   /// > - [onTap] and [onLongPress] are functions called when the card is tapped or pressed for a longer time.
   const XListTile({
     super.key,
@@ -77,13 +67,36 @@ class XListTile extends StatelessWidget {
     this.leading,
     this.trailing,
     this.margin,
-    this.density,
-    this.densityRatio,
+    this.internalHorizontalPadding,
+    this.internalVerticalPadding,
     this.onTap,
     this.onLongPress,
   });
 
   /// Returns an instance of [XCard] matching the given parameters.
+  ///
+  /// The internal horizontal and vertical padding match the horizontal and vertical values of the margin.
+  ///
+  /// PARAMETERS:
+  ///
+  /// > - [title], [content], [leading] and [trailing] are widgets.
+  /// > - [margin] works as usual, but by default it is computed from [density] and [densityRatio].
+  /// > - [onTap] and [onLongPress] are functions called when the card is tapped or pressed for a longer time.
+  XListTile.autoPad({
+    super.key,
+    required this.title,
+    this.content,
+    this.leading,
+    this.trailing,
+    required EdgeInsets this.margin,
+    this.onTap,
+    this.onLongPress,
+  })  : internalHorizontalPadding = margin.horizontal,
+        internalVerticalPadding = margin.vertical;
+
+  /// Returns an instance of [XListTile] matching the given parameters.
+  ///
+  /// The title and content are directly provided as [String] rather than [Widgets].
   ///
   /// PARAMETERS:
   ///
@@ -91,8 +104,7 @@ class XListTile extends StatelessWidget {
   /// > - [titleStyle] and [contentStyle] are the styles of [title] and [content].
   /// > - [leading] and [trailing] are widgets.
   /// > - [margin] works as usual, but by default it is computed from [density] and [densityRatio].
-  /// > - [density] is the space between the different elements (title, leading, contents, etc.).
-  /// > - [densityRatio] is the ratio of horizontal density over vertical density (for instance, a value of 2 will make the internal padding twice as large as it is tall).
+  /// > - [internalHorizontalPadding] and [internalVerticalPadding] manage the spacing between the contents of the tile.
   /// > - [onTap] and [onLongPress] are functions called when the card is tapped or pressed for a longer time.
   XListTile.text({
     super.key,
@@ -103,8 +115,8 @@ class XListTile extends StatelessWidget {
     this.leading,
     this.trailing,
     this.margin,
-    this.density,
-    this.densityRatio,
+    this.internalHorizontalPadding,
+    this.internalVerticalPadding,
     this.onTap,
     this.onLongPress,
   })  : title = Text(
@@ -133,7 +145,7 @@ class XListTile extends StatelessWidget {
             leading ?? const SizedBox(),
 
             // SPACING -----------------------------------------------------------
-            SizedBox(width: leading == null ? 0 : _density),
+            SizedBox(width: leading == null ? 0 : _internalHorizontalPadding),
 
             // MAIN BOX ----------------------------------------------------------
             Expanded(
@@ -149,7 +161,7 @@ class XListTile extends StatelessWidget {
                   ),
                   Visibility(
                     visible: content != null,
-                    child: SizedBox(height: _density / _densityRatio),
+                    child: SizedBox(height: _internalVerticalPadding),
                   ),
                   Visibility(
                     visible: content != null,
@@ -164,7 +176,7 @@ class XListTile extends StatelessWidget {
             ),
 
             // SPACING -----------------------------------------------------------
-            SizedBox(width: trailing == null ? 0 : _density),
+            SizedBox(width: trailing == null ? 0 : _internalHorizontalPadding),
 
             // TRAILING ----------------------------------------------------------
             trailing ?? const SizedBox(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.2.2
+version: 1.2.3
 homepage: https://github.com/XLhinares/x_containers
 
 environment:


### PR DESCRIPTION
- :sparkles: Added an "autoPad" constructor to `XListTile` and `XCard` that matches the external and internal padding.
- :recycle: Replaced `density` and `densityRatio` properties by `internalHorizontalPadding` and `internalVerticalPadding`.
- :recycle: Changed the example to feature internal padding on `XCard`.