### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.4
+
+- :memo: Added a "breaking change" section to the README.md.
+- :speech_balloon: Changed text in the example.
+- :truck: Export `XDocumentation` class to provide access to documentation comment templates.
+
 ## 1.2.3
 
 - :sparkles: Added an "autoPad" constructor to `XListTile` and `XCard` that matches the external and internal padding.
@@ -38,7 +44,7 @@
 
 - :boom: In `XSnackbar`, the field `message` is renamed to `content` to match the naming of other classes.
 - :boom: In `XCard`, the field `subtitle` is renamed to `content` to match the naming of other classes.
-
+  
 - :recycle: Changed the example to match the breaking changes.
 
 ## 1.0.3-dev.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.6
+
+- :boom: Removed all the "unused" parameters [xTheme.getTheme]. They can instead be set by running [.copyWith] on the result (see "breaking changes" in the readme). 
+- :bug: Changed the FontFeature element in the default appbar theme provided by the [xTheme].
+
+## 1.2.5
+
+- :bug: Removes deprecated theme parameters.
+
 ## 1.2.4
 
 - :memo: Added a "breaking change" section to the README.md.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ All these are explained below.
 
 ---
 
+## List of breaking changes
+
+### 1.2.3
+
+- Replaced `density` and `densityRatio` properties by `internalHorizontalPadding` and `internalVerticalPadding` in `xTheme`, `XListTile` and `XCard`.
+
+### 1.2.0 
+
+- `XSnackbar` doesn't use the `titleStyle` and `contentStyle` properties which are handled by the text theme.
+
+### 1.1.0
+
+- In `XSnackbar`, the field `message` is renamed to `content` to match the naming of other classes.
+- In `XCard`, the field `subtitle` is renamed to `content` to match the naming of other classes.
+
+---
+
 ## **Additional information**
 
 This is my first package, feel free to check the github to add or ask any info you'd like, or give advice!

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ All these are explained below.
 
 ## List of breaking changes
 
+### 1.2.6
+
+- Removed most parameters from `xTheme.getTheme`. The reason for this change is that the goal of the function is to provide a custom theme from an easy set of parameters. The removed parameters were just overrides for the preset; and they can easily be set by running `.copyWith` to the generated theme. 
+
 ### 1.2.3
 
 - Replaced `density` and `densityRatio` properties by `internalHorizontalPadding` and `internalVerticalPadding` in `xTheme`, `XListTile` and `XCard`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,6 @@ linter:
 
     avoid_print: false  # Uncomment to disable the `avoid_print` rule
     prefer_relative_imports: true
-    avoid_returning_null_for_future: true
     always_declare_return_types: true
     prefer_double_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
     public_member_api_docs: true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,7 +38,7 @@ class Home extends StatelessWidget {
   // CONSTRUCTOR ===============================================================
 
   /// Returns an instance of [Home] matching the given parameters.
-  const Home({Key? key}) : super(key: key);
+  const Home({super.key});
 
   // BUILD =====================================================================
 

--- a/example/lib/widgets/x_container.dart
+++ b/example/lib/widgets/x_container.dart
@@ -13,7 +13,7 @@ class ExampleXContainer extends StatelessWidget {
       margin: EdgeInsets.all(XLayout.paddingS),
       child: const Text(
         "This is an [XContainer], the container I usually use.\n\n"
-        "By default it takes all the room it can, but you can wrap it in a min-sized [Row] or [Column] if you need to make it fit the size of its child.",
+        "By default it takes all the room it can, but you can wrap it in a [FittedBox] to shrink it to the size of its child.",
         textAlign: TextAlign.center,
       ),
     );

--- a/example/lib/widgets/x_dialog.dart
+++ b/example/lib/widgets/x_dialog.dart
@@ -21,8 +21,9 @@ class ExampleXDialog extends StatelessWidget {
         cancelText: "No",
         onValidate: () => toggleTheme(),
       ).show(context),
-      child: const Text(
+      child: Text(
         "Tap to display an [XDialog].",
+        style: Theme.of(context).textTheme.bodyMedium,
       ),
     );
   }

--- a/example/lib/widgets/x_snackbar.dart
+++ b/example/lib/widgets/x_snackbar.dart
@@ -9,7 +9,7 @@ class ExampleXSnackbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextButton(
-      style: ButtonStyle(
+      style: const ButtonStyle().copyWith(
         backgroundColor:
             MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
       ),

--- a/lib/src/docs.dart
+++ b/lib/src/docs.dart
@@ -1,7 +1,7 @@
 import "package:flutter/material.dart";
 
 /// An un-instantiable class containing the common documentation for the package.
-class Documentation {
+class XDocumentation {
   // CHILDREN ==================================================================
 
   // CHILD
@@ -166,7 +166,7 @@ class Documentation {
 
   // CONSTRUCTOR ===============================================================
 
-  Documentation._internal(
+  XDocumentation._internal(
     this.child,
     this.color,
     this.gradient,

--- a/lib/src/settings/x_theme.dart
+++ b/lib/src/settings/x_theme.dart
@@ -1,6 +1,5 @@
 import "dart:ui";
 
-import "package:flutter/cupertino.dart";
 import "package:flutter/material.dart";
 
 import "../../x_containers.dart";
@@ -116,79 +115,14 @@ class XTheme {
     Color? containerColor,
     Color? cardColor,
     Color? splashColor,
-    ThemeMode mode = ThemeMode.dark,
-    bool? applyElevationOverlayColor,
-    NoDefaultCupertinoThemeData? cupertinoOverrideTheme,
-    Iterable<ThemeExtension<dynamic>>? extensions,
-    InputDecorationTheme? inputDecorationTheme,
-    MaterialTapTargetSize? materialTapTargetSize,
-    PageTransitionsTheme? pageTransitionsTheme,
-    TargetPlatform? platform,
-    ScrollbarThemeData? scrollbarTheme,
-    InteractiveInkFeatureFactory? splashFactory,
-    VisualDensity? visualDensity,
-    bool? useMaterial3,
     ColorScheme? colorScheme,
-    Brightness? brightness,
-    Color? primaryColorLight,
-    Color? primaryColorDark,
-    Color? focusColor,
-    Color? hoverColor,
-    Color? canvasColor,
-    Color? scaffoldBackgroundColor,
-    Color? bottomAppBarColor,
-    Color? dividerColor,
-    Color? highlightColor,
-    Color? selectedRowColor,
-    Color? unselectedWidgetColor,
-    Color? disabledColor,
-    Color? secondaryHeaderColor,
-    Color? backgroundColor,
-    Color? dialogBackgroundColor,
-    Color? indicatorColor,
-    Color? hintColor,
-    Color? errorColor,
-    Color? toggleableActiveColor,
+    ThemeMode mode = ThemeMode.dark,
     // TYPOGRAPHY & ICONOGRAPHY
     Typography? typography,
     TextTheme? textTheme,
     TextTheme? primaryTextTheme,
     IconThemeData? iconTheme,
     IconThemeData? primaryIconTheme,
-    // COMPONENT THEMES
-    AppBarTheme? appBarTheme,
-    MaterialBannerThemeData? bannerTheme,
-    BottomAppBarTheme? bottomAppBarTheme,
-    BottomNavigationBarThemeData? bottomNavigationBarTheme,
-    BottomSheetThemeData? bottomSheetTheme,
-    ButtonBarThemeData? buttonBarTheme,
-    ButtonThemeData? buttonTheme,
-    CardTheme? cardTheme,
-    CheckboxThemeData? checkboxTheme,
-    ChipThemeData? chipTheme,
-    DataTableThemeData? dataTableTheme,
-    DialogTheme? dialogTheme,
-    DividerThemeData? dividerTheme,
-    DrawerThemeData? drawerTheme,
-    ElevatedButtonThemeData? elevatedButtonTheme,
-    FloatingActionButtonThemeData? floatingActionButtonTheme,
-    ListTileThemeData? listTileTheme,
-    NavigationBarThemeData? navigationBarTheme,
-    NavigationRailThemeData? navigationRailTheme,
-    OutlinedButtonThemeData? outlinedButtonTheme,
-    PopupMenuThemeData? popupMenuTheme,
-    ProgressIndicatorThemeData? progressIndicatorTheme,
-    RadioThemeData? radioTheme,
-    SliderThemeData? sliderTheme,
-    SnackBarThemeData? snackBarTheme,
-    SwitchThemeData? switchTheme,
-    TabBarTheme? tabBarTheme,
-    TextButtonThemeData? textButtonTheme,
-    TextSelectionThemeData? textSelectionTheme,
-    TimePickerThemeData? timePickerTheme,
-    ToggleButtonsThemeData? toggleButtonsTheme,
-    TooltipThemeData? tooltipTheme,
-    ExpansionTileThemeData? expansionTileTheme,
   }) {
     final bool isDarkMode = mode == ThemeMode.dark;
     final Color textColor = isDarkMode ? Colors.white : Colors.black;
@@ -266,52 +200,27 @@ class XTheme {
     }
 
     return res.copyWith(
-      applyElevationOverlayColor: applyElevationOverlayColor,
-      cupertinoOverrideTheme: cupertinoOverrideTheme,
-      extensions: extensions,
-      inputDecorationTheme: inputDecorationTheme ??
-          const InputDecorationTheme().copyWith(
-            filled: true,
-            fillColor: background,
-            border: OutlineInputBorder(
-              borderRadius: XLayout.brcS,
-              borderSide: BorderSide.none,
-            ),
-            contentPadding: EdgeInsets.all(
-              XLayout.paddingS,
-            ),
-          ),
-      materialTapTargetSize: materialTapTargetSize,
-      pageTransitionsTheme: pageTransitionsTheme,
-      platform: platform,
-      scrollbarTheme: scrollbarTheme,
-      splashFactory: splashFactory,
-      visualDensity: visualDensity,
-      useMaterial3: useMaterial3,
+      inputDecorationTheme: const InputDecorationTheme().copyWith(
+        filled: true,
+        fillColor: background,
+        border: OutlineInputBorder(
+          borderRadius: XLayout.brcS,
+          borderSide: BorderSide.none,
+        ),
+        contentPadding: EdgeInsets.all(
+          XLayout.paddingS,
+        ),
+      ),
       colorScheme: colorScheme ?? defaultColorScheme,
-      brightness: brightness,
-      primaryColorLight: primaryColorLight,
-      primaryColorDark: primaryColorDark,
-      focusColor: focusColor,
-      hoverColor: hoverColor,
+      brightness: isDarkMode ? Brightness.dark : Brightness.light,
       shadowColor: shadowColor,
-      canvasColor: canvasColor,
-      scaffoldBackgroundColor: scaffoldBackgroundColor ?? background,
-      bottomAppBarColor: bottomAppBarColor,
+      canvasColor: background,
+      scaffoldBackgroundColor: background,
       cardColor: cardColor,
-      dividerColor: dividerColor,
-      highlightColor: highlightColor,
+      dividerColor: backgroundAlt,
       splashColor: splashColor,
-      selectedRowColor: selectedRowColor,
-      unselectedWidgetColor: unselectedWidgetColor,
-      disabledColor: disabledColor,
-      secondaryHeaderColor: secondaryHeaderColor,
-      backgroundColor: backgroundColor ?? background,
-      dialogBackgroundColor: dialogBackgroundColor ?? secondary,
-      indicatorColor: indicatorColor,
-      hintColor: hintColor,
-      errorColor: errorColor,
-      toggleableActiveColor: toggleableActiveColor,
+      disabledColor: backgroundAlt,
+      dialogBackgroundColor: backgroundAlt,
       // TEXT THEME ------------------------------------------------------------
       typography: typography,
       textTheme: defaultTextTheme.merge(textTheme),
@@ -322,82 +231,30 @@ class XTheme {
             color: textColor,
           ),
       primaryIconTheme: primaryIconTheme,
-      appBarTheme: appBarTheme ??
-          const AppBarTheme().copyWith(
+      appBarTheme: const AppBarTheme().copyWith(
               color: secondary,
               titleTextStyle: const TextStyle().copyWith(
                 color: textColor,
                 fontSize: 24,
                 fontWeight: FontWeight.w600,
-                fontFeatures: [const FontFeature.enable("smcp")],
+                fontFeatures: [const FontFeature("smcp")],
                 letterSpacing: 0.25,
               )),
-      bannerTheme: bannerTheme,
-      bottomAppBarTheme: bottomAppBarTheme,
-      bottomNavigationBarTheme: bottomNavigationBarTheme,
-      bottomSheetTheme: bottomSheetTheme,
-      buttonBarTheme: buttonBarTheme,
-      buttonTheme: buttonTheme ??
-          (secondary == null
+      buttonTheme: (secondary == null
               ? null
               : const ButtonThemeData().copyWith(
                   buttonColor: secondary,
                 )),
-      cardTheme: cardTheme,
-      checkboxTheme: checkboxTheme ??
-          (secondary == null
-              ? null
-              : const CheckboxThemeData().copyWith(
-                  fillColor: MaterialStateProperty.all(secondary),
-                )),
-      chipTheme: chipTheme,
-      dataTableTheme: dataTableTheme,
-      dialogTheme: dialogTheme,
-      dividerTheme: dividerTheme,
-      drawerTheme: drawerTheme ??
-          (backgroundAlt == null
+      drawerTheme: (backgroundAlt == null
               ? null
               : const DrawerThemeData().copyWith(
                   backgroundColor: backgroundAlt,
                 )),
-      elevatedButtonTheme: elevatedButtonTheme,
-      floatingActionButtonTheme: floatingActionButtonTheme,
-      listTileTheme: listTileTheme,
-      navigationBarTheme: navigationBarTheme,
-      navigationRailTheme: navigationRailTheme,
-      outlinedButtonTheme: outlinedButtonTheme,
-      popupMenuTheme: popupMenuTheme,
-      progressIndicatorTheme: progressIndicatorTheme,
-      radioTheme: radioTheme,
-      sliderTheme: sliderTheme,
-      snackBarTheme: snackBarTheme,
-      switchTheme: switchTheme,
-      tabBarTheme: tabBarTheme,
-      textButtonTheme: textButtonTheme ??
-          (background == null && backgroundAlt == null
-              ? null
-              : TextButtonThemeData(
-                  // If there are no background color nor alternate background color,
-                  // the style is not changed;
-                  // Otherwise, it is set to match the alternate background color (or the
-                  // regular background color if there is none.
-                  style: const ButtonStyle().copyWith(
-                    backgroundColor: MaterialStateProperty.all<Color>(
-                        backgroundAlt ?? background!),
-                    foregroundColor:
-                        MaterialStateProperty.all<Color>(textColor),
-                  ),
-                )),
-      textSelectionTheme: textSelectionTheme ??
-          (secondary == null
+      textSelectionTheme: (secondary == null
               ? null
               : const TextSelectionThemeData().copyWith(
                   cursorColor: secondary,
                 )),
-      timePickerTheme: timePickerTheme,
-      toggleButtonsTheme: toggleButtonsTheme,
-      tooltipTheme: tooltipTheme,
-      expansionTileTheme: expansionTileTheme,
     );
   }
 }

--- a/lib/src/widgets/x_container.dart
+++ b/lib/src/widgets/x_container.dart
@@ -65,7 +65,7 @@ class XContainer extends StatelessWidget {
 
   /// Returns an instance of [XContainer] matching the given parameters.
   const XContainer({
-    Key? key,
+    super.key,
     // color
     this.color,
     this.gradient,
@@ -83,7 +83,7 @@ class XContainer extends StatelessWidget {
     this.height,
     // child
     this.child,
-  }) : super(key: key);
+  });
 
   // BUILD =====================================================================
 

--- a/lib/src/widgets/x_ink_container.dart
+++ b/lib/src/widgets/x_ink_container.dart
@@ -88,7 +88,7 @@ class XInkContainer extends StatelessWidget {
 
   /// Returns an instance of [XInkContainer] matching the given parameters.
   const XInkContainer({
-    Key? key,
+    super.key,
     this.child,
     this.color,
     this.gradient,
@@ -106,7 +106,7 @@ class XInkContainer extends StatelessWidget {
     this.onLongPress,
     this.enableSplash,
     this.splashColor,
-  }) : super(key: key);
+  });
 
   // BUILD =====================================================================
 

--- a/lib/src/widgets/x_list_tile.dart
+++ b/lib/src/widgets/x_list_tile.dart
@@ -187,5 +187,4 @@ class XListTile extends StatelessWidget {
   }
 
 // WIDGETS ===================================================================
-
 }

--- a/lib/x_containers.dart
+++ b/lib/x_containers.dart
@@ -5,6 +5,7 @@ import "src/settings/settings.dart";
 export "src/settings/settings.dart";
 export "src/dialogs/dialogs.dart";
 export "src/widgets/widgets.dart";
+export "src/docs.dart";
 
 /// The object managing the default properties and behaviors of the XContainers.
 XTheme xTheme = XTheme();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.2.3
+version: 1.2.4
 homepage: https://github.com/XLhinares/x_containers
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: x_containers
 description: A Flutter package offering more adaptive and easy-to-use container widgets.
-version: 1.2.4
+version: 1.2.6
 homepage: https://github.com/XLhinares/x_containers
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  lint: ^2.0.1
+  lint: ^2.3.0
   flutter_test:
     sdk: flutter
 
@@ -21,12 +21,13 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.1
+  flutter_lints: ^3.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter.
+  get: any
 flutter:
 
   # To add assets to your package, add an assets section, like this:


### PR DESCRIPTION
## 1.2.6

- :boom: Removed all the "unused" parameters [xTheme.getTheme]. They can instead be set by running [.copyWith] on the result (see "breaking changes" in the readme). 
- :bug: Changed the FontFeature element in the default appbar theme provided by the [xTheme].

## 1.2.5

- :bug: Removes deprecated theme parameters.

## 1.2.4

- :memo: Added a "breaking change" section to the README.md.
- :speech_balloon: Changed text in the example.
- :truck: Export `XDocumentation` class to provide access to documentation comment templates.